### PR TITLE
Look for page descriptions at depth three

### DIFF
--- a/src/wiki-crawler.js
+++ b/src/wiki-crawler.js
@@ -95,7 +95,7 @@ module.exports = {
 										flag.title = true
 									}else if(name=='div' && attribs.class=='mw-body-content'){
 										flag.self = true
-									}else if(flag.self && name=='p' && flag.depth===2){
+									}else if(flag.self && name=='p' && flag.depth===3){
 										if(flag.p_count < 3){
 											flag.description = true
 											flag.p_count++


### PR DESCRIPTION
There seems to have been a change with the structure of Wikipedia pages where descriptions were moved from 2 levels deep to 3 levels deep. Without this change all descriptions are coming through as empty strings.